### PR TITLE
Database solely using Docker

### DIFF
--- a/TripTracker.BackService/Data/TripContext.cs
+++ b/TripTracker.BackService/Data/TripContext.cs
@@ -35,21 +35,18 @@ namespace TripTracker.BackService.Data
 					{
 				new Trip
 				{
-					Id = 1,
 					Name = "MVP Summit",
 					StartDate = new DateTime(2018, 3, 5),
 					EndDate = new DateTime(2018, 3, 8)
 				},
 			new Trip
 			{
-				Id = 2,
 				Name = "DevIntersection Orlando 2018",
 				StartDate = new DateTime(2018, 3, 25),
 				EndDate = new DateTime(2018, 3, 27)
 			},
 			new Trip
 			{
-				Id = 3,
 				Name = "Build 2018",
 				StartDate = new DateTime(2018, 5, 7),
 				EndDate = new DateTime(2018, 5, 9)

--- a/TripTracker.BackService/Startup.cs
+++ b/TripTracker.BackService/Startup.cs
@@ -29,7 +29,8 @@ namespace TripTracker.BackService
 			//services.AddTransient<Models.Repository>();
 			services.AddMvc();
 
-      services.AddDbContext<TripContext>(options=> options.UseSqlite("Data Source=JeffsTrips.db"));
+		    services.AddDbContext<TripContext>(
+		        options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
 			services.AddSwaggerGen(options =>
 					options.SwaggerDoc("v1", new Info { Title = "Trip Tracker", Version = "v1" })

--- a/TripTracker.BackService/appsettings.json
+++ b/TripTracker.BackService/appsettings.json
@@ -1,4 +1,7 @@
 ﻿{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=db;Initial Catalog=TripTracker;user=sa;password=TripTracker1234$;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/TripTracker.UI/appsettings.json
+++ b/TripTracker.UI/appsettings.json
@@ -1,12 +1,12 @@
 ﻿{
 	"serviceUrl": "http://localhost:61174/",
 	"ConnectionStrings": {
-		"DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-TripTracker.UI-53bc9b9d-9d6a-45d4-8429-2a2761773502;Trusted_Connection=True;MultipleActiveResultSets=true"
+		"DefaultConnection": "Server=db;Initial Catalog=TripTracker;user=sa;password=TripTracker1234$;MultipleActiveResultSets=true"
 	},
-	"Logging": {
-		"IncludeScopes": false,
-		"LogLevel": {
-			"Default": "Warning"
-		}
-	}
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: TripTracker.BackService/Dockerfile
+    depends_on:
+      - db
 
   ui:
     image: triptrackerui


### PR DESCRIPTION
Opened an issue for your live stream about how to move this over to use the Docker SQL image instead of SQLLite and still seed the database, and come to find out, it's super easy!

We simply had to do the following:

- In our docker compose file add - **depends_on: -db** in to our backservice, letting it know to wait to build that until the database is built.

- Add a connection string to the backservice

- Change our startup.cs in the backservice to now use SqlServer and reference the newly added connection string

- I also changed it so the database wasn't adding ids, would get an error since those are autonumbered in the DB and are added automatically.